### PR TITLE
Fix typos and add update resiliency 

### DIFF
--- a/opencl-amd.sh
+++ b/opencl-amd.sh
@@ -37,9 +37,9 @@ installLatestOpenCL()
 
 installLegacyOpenCL()
 {
-		echo "Downloading Neccessary Files"
+		echo "Downloading Necessary Files"
 		wget -q --show-progress --referer=https://www.amd.com/en/support/kb/release-notes/rn-amdgpu-unified-linux-21-30 https://drivers.amd.com/drivers/linux/amdgpu-pro-21.30-1290604-rhel-8.4.tar.xz
-		echo "Installing Workaroud Package"
+		echo "Installing Workaround Package"
 		dnf copr enable sukhmeet/amdgpu-core-shim -y &> /dev/null
 		dnf install amdgpu-core-shim -y
 		echo "Extracting Files"
@@ -129,7 +129,7 @@ menu()
             "Uninstall")
                 echo "Uninstalling OpenCL Stack"
                 uninstallOpenCL
-                echo "Uninstall Successfull"
+                echo "Uninstall Successful"
                 break
                 ;;
             "Quit")


### PR DESCRIPTION
Created getVersions() function to let the script automatically grab the latest versions of the drivers. This makes the script a bit more update-resilient; we no longer need to manually update the script with hard-coded values when an update comes out.

$LatestDriverVersion will always be the latest version of the AMD driver. 

$LatestRHEL will always be the latest RHEL version that the AMD driver supports. I may change some aspect of this functionality in the future, in case the script will be used on an older version of a RHEL-family distro. For now I think it's fine since most users are probably using Fedora, and most likely will run the latest version of Fedora. I suppose this may make it more complicated for some. Crucify me if this is poor practical design. I'm new.
